### PR TITLE
[Fix] Github SPA에 따른 함수 미실행 오류 문제 해결

### DIFF
--- a/content.js
+++ b/content.js
@@ -103,6 +103,3 @@ const observer = new MutationObserver(() => {
 
 // Start observing the document body for added/removed nodes in the entire subtree.
 observer.observe(document.body, { childList: true, subtree: true });
-
-// Run the function once on initial load. This handles cases where the user lands directly on the 'Files changed' page, as the observer only fires on changes.
-injectDescription();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GitHub Pull Request Helper",
-  "version": "1.0",
+  "version": "1.1.0",
   "description": "GitHub Pull Request 관련 다양한 부가 기능들을 이용해보세요.",
   "icons": {
     "16": "images/logo_16.png",
@@ -15,7 +15,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://github.com/*/*/pull/*/files"],
+      "matches": ["https://github.com/*"],    
       "js": ["content.js"],
       "css": ["style.css"]
     }


### PR DESCRIPTION
## Describe the Bug

링크를 통한 Pull Request 내 'File Changed' 탭에 접속하지 않고, Github 웹 페이지 초기 화면 접속 후 Pull Request 확인 시 메인 함수(`injectDescription()`) 미실행 문제 발견

1. Github 웹페이지 SPA로 인한 초기 접속 이후 페이지 새로고침 미실행
2. 이에 따라, 초기 페이지 (`https://github.com`) 이후 새로고침이 되지 않아 manifest.json 내 matches 경로 인식 불가 문제 발생

## Solution

- manifest.json 내 `content.js` 매치 경로 수정: `https://github.com/*/*/pull/*/files` → `https://github.com/*`

## Acceptance Criteria

- [x] Github 초기 웹 페이지로 접속 후, 리포지토리의 Pull Request 'File Changed' 탭을 확인하여도 바로 Description이 보이는가?

## etc
- 초기 접속 이후 `MutationObserver`에 의한 `documentation.body` 변화 감지 ⇒ 변화 시, 현재 url 경로를 확인해 메인 함수(`injectDescription()`) 호출
⇒ 이에 따른, `content.js` 파일 내 초기 함수 호출 구문 불필요 ⇒ 삭제 처리 